### PR TITLE
Send customer_id and token with every span

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ except paid.Error as e:
     print(e.raw_response)
 ```
 
+## Logging
+
+Supported log levels are `DEBUG`, `INFO`, `WARNING`, `ERROR`, and `CRITICAL`.
+
+For example, to set the log level to debug, you can set the environment variable:
+```bash
+export PAID_LOG_LEVEL=DEBUG
+```
+Falls back to `INFO`
+
 ## Cost Tracking
 
 As of now, the following OpenAI python APIs are supported:

--- a/src/paid/tracing/tracing.py
+++ b/src/paid/tracing/tracing.py
@@ -2,6 +2,7 @@
 import asyncio
 import contextvars
 import logging
+import os
 from typing import Optional, TypeVar, Callable, Union, Awaitable, Tuple, Dict
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
@@ -10,7 +11,10 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 # from opentelemetry.instrumentation.openai import OpenAIInstrumentor
 
-logging.basicConfig(level=logging.INFO)
+# Configure logging
+log_level_name = os.environ.get("PAID_LOG_LEVEL", "INFO").upper()
+log_level = getattr(logging, log_level_name, logging.INFO)
+logging.basicConfig(level=log_level)
 logger = logging.getLogger(__name__)
 
 _token: Optional[str] = None


### PR DESCRIPTION
This is needed in case OTLP flushes spans whose parent span hasn't yet ended, so that the backend has information where the updates should go.
Also added configurable logging.