### PR TITLE
Unblock the customer with the type error from the generated code.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "paid-python"
 
 [tool.poetry]
 name = "paid-python"
-version = "0.0.5-alpha6"
+version = "0.0.5-alpha7"
 description = ""
 readme = "README.md"
 authors = []

--- a/src/paid/core/pydantic_utilities.py
+++ b/src/paid/core/pydantic_utilities.py
@@ -41,7 +41,7 @@ def parse_obj_as(type_: Type[T], object_: Any) -> T:
     if IS_PYDANTIC_V2:
         adapter = pydantic.TypeAdapter(type_)  # type: ignore[attr-defined]
         return adapter.validate_python([dealiased_object])
-    return pydantic.parse_obj_as(type_, dealiased_object)
+    return pydantic.parse_obj_as(type_, [dealiased_object])
 
 
 def to_jsonable_with_fallback(obj: Any, fallback_serializer: Callable[[Any], Any]) -> Any:


### PR DESCRIPTION
When we're gonna regenerate SDK with fern, in the API spec make the return type not array. Or maybe actually send arrays from the backend.